### PR TITLE
Update 6.2httpserver.md

### DIFF
--- a/docs/jupiter/6.2httpserver.md
+++ b/docs/jupiter/6.2httpserver.md
@@ -17,7 +17,7 @@
 ```toml
 [jupiter.server.http]
     host = "127.0.0.1"
-    port = "9091"
+    port = 9091
 ```
 
 


### PR DESCRIPTION
端口号配置字符串会启动失败：【* 'Port' expected type 'int', got unconvertible type 'string'】